### PR TITLE
Active management of the MSE Source Buffer

### DIFF
--- a/dash.d.ts
+++ b/dash.d.ts
@@ -973,6 +973,7 @@ declare namespace dashjs {
                 detectPlayreadyMessageFormat?: boolean,
             },
             buffer?: {
+                activeSourceBufferManagement?: boolean,
                 enableSeekDecorrelationFix?: boolean,
                 fastSwitchEnabled?: boolean,
                 flushBufferAtTrackSwitch?: boolean,
@@ -986,7 +987,9 @@ declare namespace dashjs {
                 hybridSwitchBufferTime?: number,
                 longFormContentDurationThreshold?: number,
                 stallThreshold?: number,
+                loadThreshold?: number,
                 lowLatencyStallThreshold?: number,
+                lowLatencyLoadThreshold?: number,
                 useAppendWindow?: boolean,
                 setStallState?: boolean
                 videoFramesNotAdvancing?: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -973,6 +973,7 @@ declare namespace dashjs {
                 detectPlayreadyMessageFormat?: boolean,
             },
             buffer?: {
+                activeSourceBufferManagement?: boolean,
                 enableSeekDecorrelationFix?: boolean,
                 fastSwitchEnabled?: boolean,
                 flushBufferAtTrackSwitch?: boolean,
@@ -986,7 +987,9 @@ declare namespace dashjs {
                 hybridSwitchBufferTime?: number,
                 longFormContentDurationThreshold?: number,
                 stallThreshold?: number,
+                loadThreshold?: number,
                 lowLatencyStallThreshold?: number,
+                lowLatencyLoadThreshold?: number,
                 useAppendWindow?: boolean,
                 setStallState?: boolean
                 videoFramesNotAdvancing?: {

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -325,7 +325,10 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.cmcdAllKeys = ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v']
 
     $scope.stallThreshold = 0.3;
+    $scope.loadThreshold = 0.3;
+
     $scope.lowLatencyStallThreshold = 0.3;
+    $scope.lowLatencyLoadThreshold = 0.3;
 
     // Persistent license
     $scope.persistentSessionId = {};
@@ -828,11 +831,31 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         });
     }
 
+    $scope.updateLoadThreshold = function () {
+        $scope.player.updateSettings({
+            streaming: {
+                buffer: {
+                    loadThreshold: parseFloat($scope.loadThreshold)
+                }
+            }
+        });
+    }
+
     $scope.updateLowLatencyStallThreshold = function () {
         $scope.player.updateSettings({
             streaming: {
                 buffer: {
                     lowLatencyStallThreshold: parseFloat($scope.lowLatencyStallThreshold)
+                }
+            }
+        });
+    }
+
+    $scope.updateLowLatencyLoadThreshold = function () {
+        $scope.player.updateSettings({
+            streaming: {
+                buffer: {
+                    lowLatencyLoadThreshold: parseFloat($scope.lowLatencyLoadThreshold)
                 }
             }
         });
@@ -1110,9 +1133,19 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             config.streaming.buffer.stallThreshold = stallThreshold;
         }
 
+        const loadThreshold = parseFloat($scope.loadThreshold);
+        if (!isNaN(stallThreshold)) {
+            config.streaming.buffer.loadThreshold = loadThreshold;
+        }
+
         const lowLatencyStallThreshold = parseFloat($scope.lowLatencyStallThreshold);
         if (!isNaN(lowLatencyStallThreshold)) {
             config.streaming.buffer.lowLatencyStallThreshold = lowLatencyStallThreshold;
+        }
+
+        const lowLatencyLoadThreshold = parseFloat($scope.lowLatencyLoadThreshold);
+        if (!isNaN(lowLatencyLoadThreshold)) {
+            config.streaming.buffer.lowLatencyLoadThreshold = lowLatencyLoadThreshold;
         }
 
         config.streaming.cmcd.sid = $scope.cmcdSessionId ? $scope.cmcdSessionId : null;
@@ -2253,7 +2286,9 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         }
         if (currentConfig.streaming.abr.maxBitrate.video !== -1) {
             $scope.stallThreshold = currentConfig.streaming.buffer.stallThreshold;
+            $scope.loadThreshold = currentConfig.streaming.buffer.loadThreshold;
             $scope.lowLatencyStallThreshold = currentConfig.streaming.buffer.lowLatencyStallThreshold;
+            $scope.lowLatencyLoadThreshold = currentConfig.streaming.buffer.lowLatencyLoadThreshold;
         }
 
         if ($scope.player.getInitialMediaSettingsFor('audio')) {

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -720,9 +720,17 @@
                     <label class="options-label">Stall Threshold:</label>
                     <input type="text" class="form-control" placeholder="value in seconds" ng-model="stallThreshold"
                         ng-change="updateStallThreshold()">
+                    <label class="options-label">Load Threshold:</label>
+                    <input type="text" class="form-control" placeholder="value in seconds" ng-model="loadThreshold"
+                        ng-change="updateLoadThreshold()">
+
                     <label class="options-label">Low Latency Stall Threshold:</label>
                     <input type="text" class="form-control" placeholder="value in seconds" ng-model="lowLatencyStallThreshold"
                         ng-change="updateLowLatencyStallThreshold()">
+                    <label class="options-label">Low Latency Load Threshold:</label>
+                    <input type="text" class="form-control" placeholder="value in seconds" ng-model="lowLatencyLoadThreshold"
+                        ng-change="updateLowLatencyLoadThreshold()">
+
                 </div>
             </div>
         </div>

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -93,6 +93,7 @@ import Events from './events/Events';
  *                detectPlayreadyMessageFormat: true,
  *            },
  *            buffer: {
+ *                activeSourceBufferManagement: false,
  *                enableSeekDecorrelationFix: false,
  *                fastSwitchEnabled: true,
  *                flushBufferAtTrackSwitch: false,
@@ -106,7 +107,9 @@ import Events from './events/Events';
  *                hybridSwitchBufferTime: NaN,
  *                longFormContentDurationThreshold: 600,
  *                stallThreshold: 0.3,
+ *                loadThreshold: 0.3, 
  *                lowLatencyStallThreshold: 0.3,
+ *                lowLatencyLoadThreshold: 0.3,
  *                useAppendWindow: true,
  *                setStallState: true,
  *                videoFramesNotAdvancing: {
@@ -295,6 +298,10 @@ import Events from './events/Events';
 
 /**
  * @typedef {Object} Buffer
+ * @property {boolean} [activeSourceBufferManagement=false]
+ * Put Dash.js in contol of the MSE source buffer level preventing and stopping playback when the stall and load buffer thresholds are met.
+ * 
+ * If you expirence short stall on startup, particularly on TV devices this setting may be useful.
  * @property {boolean} [enableSeekDecorrelationFix=false]
  * Enables a workaround for playback start on some devices, e.g. WebOS 4.9.
  * It is necessary because some browsers do not support setting currentTime on video element to a value that is outside of current buffer.
@@ -350,8 +357,12 @@ import Events from './events/Events';
  * When the time is set higher than the default you will have to wait longer to see automatic bitrate switches but will have a larger buffer which will increase stability.
  * @property {number} [stallThreshold=0.3]
  * Stall threshold used in BufferController.js to determine whether a track should still be changed and which buffer range to prune.
- * @property {number} [lowLatencyStallThreshold=0.3]
+ * @property {boolean} [loadThreshold=0.3]
+ * Specifies the length of media required in the buffer before starting playback, either for the first time or recvovering from a stall.  
+* @property {number} [lowLatencyStallThreshold=0.3]
  * Low Latency stall threshold used in BufferController.js to determine whether a track should still be changed and which buffer range to prune. 
+ * @property {boolean} [lowLatencyLoadThreshold=0.3]
+ * In Low latency mode specifies the length of media required in the buffer before starting playback, either for the first time or recvovering from a stall. 
  * @property {boolean} [useAppendWindow=true]
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=true]
@@ -983,6 +994,7 @@ function Settings() {
                 detectPlayreadyMessageFormat: true,
             },
             buffer: {
+                activeSourceBufferManagement: false,
                 enableSeekDecorrelationFix: false,
                 fastSwitchEnabled: true,
                 flushBufferAtTrackSwitch: false,
@@ -996,7 +1008,9 @@ function Settings() {
                 hybridSwitchBufferTime: NaN,
                 longFormContentDurationThreshold: 600,
                 stallThreshold: 0.3,
+                loadThreshold: 0.3,
                 lowLatencyStallThreshold: 0.3,
+                lowLatencyLoadThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
                 videoFramesNotAdvancing: {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -866,12 +866,13 @@ function BufferController(config) {
             return;
         }
 
-        //Set stall threshold based on player mode
+        //Set stall and load threshold based on player mode
         const stallThreshold = playbackController.getLowLatencyModeEnabled() ? settings.get().streaming.buffer.lowLatencyStallThreshold : settings.get().streaming.buffer.stallThreshold;
-        
+        const loadThreshold = playbackController.getLowLatencyModeEnabled() ? settings.get().streaming.buffer.lowLatencyLoadThreshold : settings.get().streaming.buffer.loadThreshold;
+
         if ((bufferLevel <= stallThreshold) && !isBufferingCompleted) {
             _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
-        } else if (isBufferingCompleted || bufferLevel > stallThreshold) {
+        } else if (isBufferingCompleted || bufferLevel > loadThreshold) {
             _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
         }
     }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -142,6 +142,10 @@ function PlaybackController() {
         eventBus.on(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.on(MediaPlayerEvents.DYNAMIC_TO_STATIC, _onDynamicToStatic, instance);
 
+        if (settings.get().streaming.buffer.activeSourceBufferManagement) {
+            videoModel.setPlaybackRate(0, true);
+        }
+
         if (playOnceInitialized) {
             playOnceInitialized = false;
             play();
@@ -595,6 +599,15 @@ function PlaybackController() {
         }
 
         playbackStalled = e.state === MetricsConstants.BUFFER_EMPTY;
+
+        if (settings.get().streaming.buffer.activeSourceBufferManagement) {
+            if (e.state === MetricsConstants.BUFFER_EMPTY) {
+                videoModel.setPlaybackRate(0, true);
+            } else if (e.state === MetricsConstants.BUFFER_LOADED) {
+                console.log(getBufferLevel())
+                videoModel.setPlaybackRate(1, true);
+            }
+        }
 
         if (settings.get().streaming.buffer.setStallState) {
             videoModel.setStallState(e.mediaType, e.state === MetricsConstants.BUFFER_EMPTY);

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -604,7 +604,6 @@ function PlaybackController() {
             if (e.state === MetricsConstants.BUFFER_EMPTY) {
                 videoModel.setPlaybackRate(0, true);
             } else if (e.state === MetricsConstants.BUFFER_LOADED) {
-                console.log(getBufferLevel())
                 videoModel.setPlaybackRate(1, true);
             }
         }


### PR DESCRIPTION
Introduces some additional settings and a flag to control their use.

Provides a mechanism for Dash.js to control the level of the MSE source buffer on startup or recovery from a a stall in order to prevent short stalls.

Many TV devices already appear to take steps to do this in their MSE implementations. Here, we provide a universal mechanism to ensure all devices benefit from a cautious startup after a stall.

 New settings:

* `loadThreshold` - Compliments `stallThreshold` symmetric by default, but allows a difference recovery threshold to be set than the stall threshold for a more cautious startup.
* `lowLatencyLoadThreshold` - Low latency equivalent of the above. Compliments `lowLatencyStallThreshold` symmetric by default but allows a difference recovery threshold to be set than the stall threshold for a more cautious startup.
* `activeSourceBufferManagement`  - Controls whether the above are used to stop playback (by setting rate to 0) in the period of time between `BUFFER_EMPTY` and `BUFFER_LOADED` events. 