### PR TITLE
Progress timer fix

### DIFF
--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -33,6 +33,7 @@ import FactoryMaker from '../../core/FactoryMaker';
 import Settings from '../../core/Settings';
 import Constants from '../constants/Constants';
 import { modifyRequest } from '../utils/RequestModifier';
+import Debug from '../../core/Debug';
 
 /**
  * @module FetchLoader
@@ -43,12 +44,15 @@ import { modifyRequest } from '../utils/RequestModifier';
 function FetchLoader(cfg) {
 
     cfg = cfg || {};
+    
+    let instance, dashMetrics;
+
     const context = this.context;
+    const logger = Debug(context).getInstance().getLogger(instance);
     const requestModifier = cfg.requestModifier;
     const lowLatencyThroughputModel = cfg.lowLatencyThroughputModel;
     const boxParser = cfg.boxParser;
     const settings = Settings(context).getInstance();
-    let instance, dashMetrics;
 
     function setup(cfg) {
         dashMetrics = cfg.dashMetrics;
@@ -344,7 +348,9 @@ function FetchLoader(cfg) {
                     read(httpRequest, processResult);
                 })
                     .catch(function (e) {
-                        if (httpRequest.onerror) {
+                        if (e.name == 'AbortError') {
+                            logger.warn('processResult caught AbortError: Request ' + httpRequest.url + ' aborted', e);
+                        } else if (httpRequest.onerror) {
                             httpRequest.onerror(e);
                         }
                     });
@@ -355,7 +361,9 @@ function FetchLoader(cfg) {
         httpRequest.reader.read()
             .then(processResult)
             .catch(function (e) {
-                if (httpRequest.onerror && httpRequest.response.status === 200) {
+                if (e.name == 'AbortError') {
+                    logger.warn('Reader caught AbortError: Request ' + httpRequest.url + ' aborted', e);
+                } else  if (httpRequest.onerror && httpRequest.response.status === 200) {
                     // Error, but response code is 200, trigger error
                     httpRequest.onerror(e);
                 }

--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -44,9 +44,7 @@ import Debug from '../../core/Debug';
 function FetchLoader(cfg) {
 
     cfg = cfg || {};
-    
     let instance, dashMetrics;
-
     const context = this.context;
     const logger = Debug(context).getInstance().getLogger(instance);
     const requestModifier = cfg.requestModifier;
@@ -137,10 +135,15 @@ function FetchLoader(cfg) {
             .then(() => {
                 let markBeforeFetch = Date.now();
 
+                if (!httpRequest.response) {
+                    httpRequest.response = {
+                        status: 0,
+                        statusText: 'No status received',
+                        responseURL: httpRequest.url
+                    };
+                }
+
                 fetch(httpRequest.url, reqOptions).then(function (response) {
-                    if (!httpRequest.response) {
-                        httpRequest.response = {};
-                    }
                     httpRequest.response.status = response.status;
                     httpRequest.response.statusText = response.statusText;
                     httpRequest.response.responseURL = response.url;

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -142,6 +142,7 @@ function HTTPLoader(cfg) {
         };
 
         const onloadend = function () {
+            console.log('onloadend', httpRequest, httpRequest.response ? httpRequest.response.status : null, httpRequest.response ? httpRequest.response.responseURL : null, needFailureReport, remainingAttempts);
             if (progressTimeout) {
                 clearTimeout(progressTimeout);
                 progressTimeout = null;
@@ -238,7 +239,14 @@ function HTTPLoader(cfg) {
                 progressTimeout = setTimeout(function () {
                     // No more progress => abort request and treat as an error
                     logger.warn('Abort request ' + httpRequest.url + ' due to progress timeout');
-                    httpRequest.response.onabort = null;
+                    // Suppress onabort across all loader paths so config.abort is not called.
+                    if (httpRequest.response) {
+                        httpRequest.response.onabort = null;  // Suppress XHR path
+                    }
+                    if (httpRequest.abortController) {
+                        httpRequest.abortController.signal.onabort = null;  // Suppress Fetch AbortController path
+                    }
+                    httpRequest.onabort = null;  // Suppress calling this directly from Fetch abort reader path
                     httpRequest.loader.abort(httpRequest);
                     onloadend();
                 }, settings.get().streaming.fragmentRequestProgressTimeout);
@@ -250,6 +258,7 @@ function HTTPLoader(cfg) {
         };
 
         const onload = function () {
+            console.log('onload', httpRequest.response.status, httpRequest.response.responseURL);
             if (httpRequest.response.status >= 200 && httpRequest.response.status <= 299) {
                 if (hasContentLengthMismatch(httpRequest.response)) {
                     const responseUrl = httpRequest.response.responseURL;

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -192,7 +192,7 @@ function HTTPLoader(cfg) {
                     }));
 
                     if (config.error) {
-                        config.error(request, 'error', httpRequest.response.statusText, httpRequest.response);
+                        config.error(request, 'error', httpRequest.response?.statusText, httpRequest.response);
                     }
 
                     if (config.complete) {

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -123,7 +123,7 @@ function HTTPLoader(cfg) {
             const responseUrl = httpRequest.response ? httpRequest.response.responseURL : null;
             const responseStatus = httpRequest.response ? httpRequest.response.status : null;
             const responseHeaders = httpRequest.response && httpRequest.response.getAllResponseHeaders ? httpRequest.response.getAllResponseHeaders() :
-                httpRequest.response ? httpRequest.response.responseHeaders : null;
+                httpRequest.response && httpRequest.response.responseHeaders ? httpRequest.response.responseHeaders : null;
 
             const cmsd = responseHeaders && settings.get().streaming.cmsd && settings.get().streaming.cmsd.enabled ? cmsdModel.parseResponseHeaders(responseHeaders, request.mediaType) : null;
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -192,7 +192,7 @@ function HTTPLoader(cfg) {
                     }));
 
                     if (config.error) {
-                        config.error(request, 'error', httpRequest.response?.statusText, httpRequest.response);
+                        config.error(request, 'error', httpRequest.response.statusText, httpRequest.response);
                     }
 
                     if (config.complete) {

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -142,7 +142,6 @@ function HTTPLoader(cfg) {
         };
 
         const onloadend = function () {
-            console.log('onloadend', httpRequest, httpRequest.response ? httpRequest.response.status : null, httpRequest.response ? httpRequest.response.responseURL : null, needFailureReport, remainingAttempts);
             if (progressTimeout) {
                 clearTimeout(progressTimeout);
                 progressTimeout = null;
@@ -258,7 +257,6 @@ function HTTPLoader(cfg) {
         };
 
         const onload = function () {
-            console.log('onload', httpRequest.response.status, httpRequest.response.responseURL);
             if (httpRequest.response.status >= 200 && httpRequest.response.status <= 299) {
                 if (hasContentLengthMismatch(httpRequest.response)) {
                     const responseUrl = httpRequest.response.responseURL;


### PR DESCRIPTION
   Correct Progress timer onabort() handling

    - The original implementation was based around XMLRequest operation and
      fails to work correctly with the FetchLoader
    - This change ensures that config.abort() is not called for XHR or Fetch
      (otherwise it results in another segment request which is not intended
      with the progresstimer - instead a configured number of retries for
      the same segment are made.
